### PR TITLE
Allow a greater range of types as a stack trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0
+
+* Change type of `stackTrace` from `StackTrace` to `Object`.
+
 ## 0.9.3
 
 * Added optional `LogRecord.zone` field.

--- a/lib/logging.dart
+++ b/lib/logging.dart
@@ -147,7 +147,7 @@ class Logger {
    */
   void log(Level logLevel,
            message,
-           [Object error, StackTrace stackTrace, Zone zone]) {
+           [Object error, Object stackTrace, Zone zone]) {
     if (isLoggable(logLevel)) {
       // If message is a Function, evaluate it.
       if (message is Function) message = message();
@@ -172,35 +172,35 @@ class Logger {
   }
 
   /** Log message at level [Level.FINEST]. */
-  void finest(message, [Object error, StackTrace stackTrace]) =>
+  void finest(message, [Object error, Object stackTrace]) =>
       log(Level.FINEST, message, error, stackTrace);
 
   /** Log message at level [Level.FINER]. */
-  void finer(message, [Object error, StackTrace stackTrace]) =>
+  void finer(message, [Object error, Object stackTrace]) =>
       log(Level.FINER, message, error, stackTrace);
 
   /** Log message at level [Level.FINE]. */
-  void fine(message, [Object error, StackTrace stackTrace]) =>
+  void fine(message, [Object error, Object stackTrace]) =>
       log(Level.FINE, message, error, stackTrace);
 
   /** Log message at level [Level.CONFIG]. */
-  void config(message, [Object error, StackTrace stackTrace]) =>
+  void config(message, [Object error, Object stackTrace]) =>
       log(Level.CONFIG, message, error, stackTrace);
 
   /** Log message at level [Level.INFO]. */
-  void info(message, [Object error, StackTrace stackTrace]) =>
+  void info(message, [Object error, Object stackTrace]) =>
       log(Level.INFO, message, error, stackTrace);
 
   /** Log message at level [Level.WARNING]. */
-  void warning(message, [Object error, StackTrace stackTrace]) =>
+  void warning(message, [Object error, Object stackTrace]) =>
       log(Level.WARNING, message, error, stackTrace);
 
   /** Log message at level [Level.SEVERE]. */
-  void severe(message, [Object error, StackTrace stackTrace]) =>
+  void severe(message, [Object error, Object stackTrace]) =>
       log(Level.SEVERE, message, error, stackTrace);
 
   /** Log message at level [Level.SHOUT]. */
-  void shout(message, [Object error, StackTrace stackTrace]) =>
+  void shout(message, [Object error, Object stackTrace]) =>
       log(Level.SHOUT, message, error, stackTrace);
 
   Stream<LogRecord> _getStream() {
@@ -322,7 +322,7 @@ class LogRecord {
   final Object error;
 
   /** Associated stackTrace (if any) when recording errors messages. */
-  final StackTrace stackTrace;
+  final Object stackTrace;
 
   /** Zone of the calling code which resulted in this LogRecord. */
   final Zone zone;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: logging
-version: 0.9.3
+version: 0.10.0
 author: Dart Team <misc@dartlang.org>
 description: >
   Provides APIs for debugging and error logging. This library introduces


### PR DESCRIPTION
I'm currently working with isolates and notices the following problem: The callback registered with an ```addErrorListener``` on an isolate received an error and a ```String``` as a stack trace. However, ```LogRecord``` expects for ```stackTrace``` a ```StackTrace```. I expect this is a limitation of the isolate library and not solvable there. This means I can't pass the received stack trace to the ```LogRecord```.

This pull request changes the type of ```stackTrace``` to ```Object``` so that one can also pass a ```String```. The ```error``` member is already of type ```Object```. That wouldn't change any behavior but would allow for a broader usage.
