### PR TITLE
Improve Logger.root (make it a final field instead of a getter)

### DIFF
--- a/lib/logging.dart
+++ b/lib/logging.dart
@@ -229,7 +229,7 @@ class Logger {
   }
 
   /** Top-level root [Logger]. */
-  static Logger get root => new Logger('');
+  static final Logger root = new Logger('');
 
   /** All [Logger]s in the system. */
   static final Map<String, Logger> _loggers = <String, Logger>{};


### PR DESCRIPTION
Notes:
- Static fields are lazy
- The getter is always returning the same cached instance anyway (that's a factory constructor).