### PR TITLE
Add Logger.orphan factory

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@
 #   Organization <fnmatch pattern>
 #
 Google Inc. <*@google.com>
+Anton Astashov <anton.astashov@gmail.com>

--- a/lib/logging.dart
+++ b/lib/logging.dart
@@ -61,6 +61,18 @@ class Logger {
     return _loggers.putIfAbsent(name, () => new Logger._named(name));
   }
 
+  /// Creates a new detached [Logger].
+  ///
+  /// Returns a new [Logger] instance (unlike [new Logger], which returns a
+  /// [Logger] singleton), which doesn't have any parent or children,
+  /// and it's not a part of the global hierarchial loggers structure.
+  ///
+  /// It can be useful when you just need a local short-living logger,
+  /// which you'd like to be garbage-collected later.
+  factory Logger.detached(String name) {
+    return new Logger._internal(name, null, new Map<String, Logger>());
+  }
+
   factory Logger._named(String name) {
     if (name.startsWith('.')) {
       throw new ArgumentError("name shouldn't start with a '.'");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: logging
-version: 0.11.1+1
+version: 0.11.2
 author: Dart Team <misc@dartlang.org>
 description: >
   Provides APIs for debugging and error logging. This library introduces

--- a/test/logging_test.dart
+++ b/test/logging_test.dart
@@ -206,6 +206,28 @@ void main() {
     });
   });
 
+  group('detached loggers', () {
+    test("create new instances of Logger", () {
+      Logger a1 = new Logger.detached("a");
+      Logger a2 = new Logger.detached("a");
+      Logger a = new Logger("a");
+
+      expect(a1, isNot(a2));
+      expect(a1, isNot(a));
+      expect(a2, isNot(a));
+    });
+
+    test("parent is null", () {
+      Logger a = new Logger.detached("a");
+      expect(a.parent, null);
+    });
+
+    test("children is empty", () {
+      Logger a = new Logger.detached("a");
+      expect(a.children, {});
+    });
+  });
+
   group('mutating levels', () {
     Logger root = Logger.root;
     Logger a = new Logger('a');


### PR DESCRIPTION
Sometimes you just don't need to add a logger, which will be a singleton
and part of the global loggers tree. So, just a logger, which will be
garbage collected, and its onRecord.listen won't subscribe to the root one.
Right now, there is theoretical possibility for that, but a constructor
for that is private.

Added Logger.orphan factory, which is doing exactly this.