### PR TITLE
Make detached Loggers work regardless of hierarchicalLoggingEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add top level `defaultLevel`.
 * Require Dart `>=2.0.0`.
+* Make detached loggers work regardless of `hierarchicalLoggingEnabled`.
 
 ## 0.11.3+2
 
@@ -21,7 +22,7 @@
 
 ## 0.11.2
 
-* Added Logger.detached - a convenience factory to obtain a logger that is not
+* Added `Logger.detached` - a convenience factory to obtain a logger that is not
   attached to this library's logger hierarchy.
 
 ## 0.11.1+1

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -90,17 +90,22 @@ class Logger {
   /// Effective level considering the levels established in this logger's
   /// parents (when [hierarchicalLoggingEnabled] is true).
   Level get level {
-    // `!hierarchicalLoggingEnabled` does not imply `_level == null`, so the
-    // order of the following checks matters.
+    Level effectiveLevel;
+
     if (parent == null) {
+      // We're either the root logger or a detached logger.  Return our own
+      // level.
+      effectiveLevel = _level;
     } else if (!hierarchicalLoggingEnabled) {
-      return root._level;
-    } else if (_level == null) {
-      return parent.level;
+      effectiveLevel = root._level;
+    } else if (_level != null) {
+      effectiveLevel = _level;
+    } else {
+      effectiveLevel = parent.level;
     }
 
-    assert(_level != null);
-    return _level;
+    assert(effectiveLevel != null);
+    return effectiveLevel;
   }
 
   /// Override the level for this particular [Logger] and its children.

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -80,7 +80,9 @@ class Logger {
   Logger._internal(this.name, this.parent, Map<String, Logger> children)
       : _children = children,
         children = UnmodifiableMapView(children) {
-    if (parent != null) {
+    if (parent == null) {
+      _level = defaultLevel;
+    } else {
       parent._children[name] = this;
     }
   }
@@ -88,25 +90,27 @@ class Logger {
   /// Effective level considering the levels established in this logger's
   /// parents (when [hierarchicalLoggingEnabled] is true).
   Level get level {
-    if (hierarchicalLoggingEnabled) {
-      if (_level != null) return _level;
-      if (parent != null) return parent.level;
+    // `!hierarchicalLoggingEnabled` does not imply `_level == null`, so the
+    // order of the following checks matters.
+    if (parent == null) {
+    } else if (!hierarchicalLoggingEnabled) {
+      return root._level;
+    } else if (_level == null) {
+      return parent.level;
     }
-    return root._level;
+
+    assert(_level != null);
+    return _level;
   }
 
   /// Override the level for this particular [Logger] and its children.
   set level(Level value) {
-    if (hierarchicalLoggingEnabled && parent != null) {
-      _level = value;
-    } else {
-      if (parent != null) {
-        throw UnsupportedError(
-            'Please set "hierarchicalLoggingEnabled" to true if you want to '
-            'change the level on a non-root logger.');
-      }
-      root._level = value;
+    if (!hierarchicalLoggingEnabled && parent != null) {
+      throw UnsupportedError(
+          'Please set "hierarchicalLoggingEnabled" to true if you want to '
+          'change the level on a non-root logger.');
     }
+    _level = value;
   }
 
   /// Returns a stream of messages added to this [Logger].
@@ -174,14 +178,16 @@ class Logger {
       var record =
           LogRecord(logLevel, msg, fullName, error, stackTrace, zone, object);
 
-      if (hierarchicalLoggingEnabled) {
+      if (parent == null) {
+        _publish(record);
+      } else if (!hierarchicalLoggingEnabled) {
+        root._publish(record);
+      } else {
         var target = this;
         while (target != null) {
           target._publish(record);
           target = target.parent;
         }
-      } else {
-        root._publish(record);
       }
     }
   }
@@ -234,7 +240,7 @@ class Logger {
   }
 
   /// Top-level root [Logger].
-  static final Logger root = Logger('').._level = defaultLevel;
+  static final Logger root = Logger('');
 
   /// All [Logger]s in the system.
   static final Map<String, Logger> _loggers = <String, Logger>{};

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -98,10 +98,8 @@ class Logger {
       effectiveLevel = _level;
     } else if (!hierarchicalLoggingEnabled) {
       effectiveLevel = root._level;
-    } else if (_level != null) {
-      effectiveLevel = _level;
     } else {
-      effectiveLevel = parent.level;
+      effectiveLevel = _level ?? parent.level;
     }
 
     assert(effectiveLevel != null);


### PR DESCRIPTION
Previously detached `Logger`s could log messages only if
`hierarchicalLoggingEnabled` was true.  This makes no sense to me since
detached `Logger`s aren't part of a `Logger` hierarchy.

Fixes https://github.com/dart-lang/logging/issues/34.