### PR TITLE
Prep to merge null_safety into master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,36 @@
 language: dart
 
 dart:
-  - dev
-  - 2.0.0
+- dev
 
-dart_task:
-  - test: --platform vm
-  - test: --platform chrome
-  - dartanalyzer: --fatal-infos --fatal-warnings .
-
-matrix:
+jobs:
   include:
-    - dart: dev
-      dart_task: dartfmt
+    - stage: analyze_and_format
+      name: "Analyze"
+      os: linux
+      script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos .
+    - stage: analyze_and_format
+      name: "Format"
+      os: linux
+      script: dartfmt -n --set-exit-if-changed .
+    - stage: test
+      name: "Vm Tests"
+      os: linux
+      script: pub run --enable-experiment=non-nullable test -p vm 
+    - stage: test
+      name: "Web Tests"
+      os: linux
+      script: pub run --enable-experiment=non-nullable test -p chrome
+
+stages:
+  - analyze_and_format
+  - test
 
 # Only building master means that we don't run two builds for each pull request.
 branches:
-  only: [master]
+  only: [master, null_safety]
 
+# Incremental pub cache and builds.
 cache:
- directories:
-   - $HOME/.pub-cache
+  directories:
+  - $HOME/.pub-cache

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,9 @@ description: >-
   abstractions similar to those used in other languages, such as the Closure
   JS Logger and java.util.logging.Logger.
 homepage: https://github.com/dart-lang/logging
+# This package requires the unreleased null safety feature, and cannot be
+# published until that ships.
+publish_to: none
 
 environment:
   sdk: '>=2.10.0-0.0 <2.10.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,86 +8,13 @@ description: >-
 homepage: https://github.com/dart-lang/logging
 
 environment:
-  sdk: '>=2.9.0-1 <3.0.0'
+  sdk: '>=2.10.0-0.0 <2.10.0'
 
 dev_dependencies:
-  pedantic: ^1.3.0
-  test: ^1.3.0
+  pedantic: ^1.10.0-nullsafety
+  test: ^1.16.0-nullsafety
 
 dependency_overrides:
   # These are required to get a version solve since they depend on this package
   coverage: ^0.13.3
   webkit_inspection_protocol: ^0.5.0
-  # null safety overrides
-  async:
-    git:
-      url: git://github.com/dart-lang/async.git
-      ref: null_safety
-  boolean_selector:
-    git:
-      url: git://github.com/dart-lang/boolean_selector.git
-      ref: null_safety
-  charcode:
-    git:
-      url: git://github.com/dart-lang/charcode.git
-      ref: null_safety
-  collection:
-    git:
-      url: git://github.com/dart-lang/collection.git
-      ref: null_safety
-  matcher:
-    git:
-      url: git://github.com/dart-lang/matcher.git
-      ref: null_safety
-  meta:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      ref: null_safety-pkgs
-      path: pkg/meta
-  path:
-    git:
-      url: git://github.com/dart-lang/path.git
-      ref: null_safety
-  pedantic:
-    git:
-      url: git://github.com/dart-lang/pedantic.git
-      ref: null_safety
-  pool:
-    git:
-      url: git://github.com/dart-lang/pool.git
-      ref: null_safety
-  source_span:
-    git:
-      url: git://github.com/dart-lang/source_span.git
-      ref: null_safety
-  stack_trace:
-    git:
-      url: git://github.com/dart-lang/stack_trace.git
-      ref: null_safety
-  stream_channel:
-    git:
-      url: git://github.com/dart-lang/stream_channel.git
-      ref: null_safety
-  string_scanner:
-    git:
-      url: git://github.com/dart-lang/string_scanner.git
-      ref: null_safety
-  term_glyph:
-    git:
-      url: git://github.com/dart-lang/term_glyph.git
-      ref: null_safety
-  test_api:
-    git:
-      url: git://github.com/dart-lang/test.git
-      ref: null_safety
-      path: pkgs/test_api
-  test_core:
-    git:
-      url: git://github.com/dart-lang/test.git
-      ref: null_safety
-      path: pkgs/test_core
-  test:
-    git:
-      url: git://github.com/dart-lang/test.git
-      ref: null_safety
-      path: pkgs/test


### PR DESCRIPTION
Enables travis on the null_safety branch and passes --enable-experiment for tasks, as well as updating the sdk constraint and dependencies.