### PR TITLE
Move from pedantic to lints package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.0.2-dev
+
 ## 1.0.1
 
 * List log levels in README.
@@ -9,7 +11,7 @@
 ## 1.0.0-nullsafety.0
 
 * Migrate to null safety.
-* Removed the deprecated `LoggerHandler` typedef. 
+* Removed the deprecated `LoggerHandler` typedef.
 
 ## 0.11.4
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,12 +1,8 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 analyzer:
   strong-mode:
     implicit-casts: false
-  errors:
-    unused_element: error
-    unused_import: error
-    unused_local_variable: error
-    dead_code: error
+
 linter:
   rules:
     - annotate_overrides

--- a/lib/src/level.dart
+++ b/lib/src/level.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: constant_identifier_names
+
 /// [Level]s to control logging output. Logging can be enabled to include all
 /// levels above certain [Level]. [Level]s are ordered using an integer
 /// value [Level.value]. The predefined [Level] constants below are sorted as

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: logging
-version: 1.0.1
+version: 1.0.2-dev
 
 description: >-
   Provides APIs for debugging and error logging. This library introduces
@@ -11,5 +11,5 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dev_dependencies:
-  pedantic: ^1.10.0
+  lints: ^1.0.0
   test: ^1.16.0

--- a/test/logging_test.dart
+++ b/test/logging_test.dart
@@ -605,7 +605,7 @@ void main() {
       });
 
       var callCount = 0;
-      var myClosure = () => '${++callCount}';
+      String myClosure() => '${++callCount}';
 
       root.info(myClosure);
       root.finer(myClosure); // Should not get evaluated.


### PR DESCRIPTION
Fix violation of `prefer_function_declarations_over_variables`.

Ignore `constant_identifier_names` in `level.dart` since fixing the
violations would be a breaking change.