### PR TITLE
Added a getter called loggers to return the list of all Logger objects

### DIFF
--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -280,4 +280,5 @@ class Logger {
 
   /// All [Logger]s in the system.
   static final Map<String, Logger> _loggers = <String, Logger>{};
+  static final Map<String, Logger> loggers = UnmodifiableMapView(_loggers);
 }


### PR DESCRIPTION
You could only get a map of the children of a specific Logger. This getter gives the ability to get all Loggers in the system.