### PR TITLE
turn on the avoid_dynamic_calls lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3-dev
+
+* Enable the `avoid_dynamic_calls` lint.
+
 ## 1.0.2
 
 * Update description.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,5 @@
 include: package:lints/recommended.yaml
+
 analyzer:
   strong-mode:
     implicit-casts: false
@@ -6,6 +7,7 @@ analyzer:
 linter:
   rules:
     - annotate_overrides
+    - avoid_dynamic_calls
     - avoid_function_literals_in_foreach_calls
     - avoid_init_to_null
     - avoid_null_checks_in_equality_operators

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -174,7 +174,7 @@ class Logger {
     Object? object;
     if (isLoggable(logLevel)) {
       if (message is Function) {
-        message = (message as Object Function())();
+        message = (message as Object? Function())();
       }
 
       String msg;

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -174,7 +174,7 @@ class Logger {
     Object? object;
     if (isLoggable(logLevel)) {
       if (message is Function) {
-        message = message();
+        message = (message as Object Function())();
       }
 
       String msg;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: logging
-version: 1.0.2
+version: 1.0.3-dev
 
 description: >-
   Provides APIs for debugging and error logging, similar to loggers in other


### PR DESCRIPTION
- turn on the `avoid_dynamic_calls` lint
- address the single location where this lint fired
