### PR TITLE
Add cancelLogging method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0
+## 1.2.0
 
 * Add `Logger.cancelLogging` which clear listeners for the current logger,
   and, when `hierarchicalLoggingEnabled` is true, for all children of the current logger. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.0
+## 2.0.0
 
 * Add `Logger.cancelLogging` which clear listeners for the current logger,
   and, when `hierarchicalLoggingEnabled` is true, for all children of the current logger. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+
+* Add `Logger.cancelLogging` which clear listeners for the current logger,
+  and, when `hierarchicalLoggingEnabled` is true, for all children of the current logger. 
+
 ## 1.1.0
 
 * Add `Logger.attachedLoggers` which exposes all loggers created with the

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -143,10 +143,32 @@ class Logger {
   /// ```
   Stream<LogRecord> get onRecord => _getStream();
 
+  /// Allow to cancel logging for current logger and its children
+  /// if [hierarchicalLoggingEnabled] is true.
+  /// To start listen for messages again with current logger
+  /// you should create new subscription(and for any child if required):
+  ///
+  /// ```dart
+  /// logger.onRecord.listen((record) { ... });
+  /// ```
+  ///
+  void cancelLogging() {
+    _clearListeners();
+    if (hierarchicalLoggingEnabled) {
+      for (final logger in _children.values) {
+        logger.cancelLogging();
+      }
+    }
+  }
+
+  void _clearListeners() {
+    _controller?.close();
+    _controller = null;
+  }
+
   void clearListeners() {
     if (hierarchicalLoggingEnabled || parent == null) {
-      _controller?.close();
-      _controller = null;
+      _clearListeners();
     } else {
       root.clearListeners();
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: logging
-version: 1.2.0
+version: 2.0.0
 
 description: >-
   Provides APIs for debugging and error logging, similar to loggers in other

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: logging
-version: 2.0.0
+version: 1.2.0
 
 description: >-
   Provides APIs for debugging and error logging, similar to loggers in other

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: logging
-version: 1.1.0
+version: 1.2.0
 
 description: >-
   Provides APIs for debugging and error logging, similar to loggers in other

--- a/test/logging_test.dart
+++ b/test/logging_test.dart
@@ -167,30 +167,49 @@ void main() {
     expect(shout.stackTrace, isNull);
   });
 
-  test('could not add event when logging is canceled', () {
-    final root = Logger.root;
-    final records = <LogRecord>[];
-    recordStackTraceAtLevel = Level.ALL;
-    root.onRecord.listen(records.add);
+  group(
+    'cancelLogging',
+    () {
+      final root = Logger.root;
+      final records = <LogRecord>[];
 
-    root.cancelLogging();
+      setUp(() {
+        records.clear();
+        recordStackTraceAtLevel = Level.ALL;
+      });
 
-    root.severe('hello');
-    root.warning('hello');
-    root.info('hello');
-    expect(records, hasLength(0));
-  });
+      tearDown(() {
+        recordStackTraceAtLevel = Level.OFF;
+        root.clearListeners();
+      });
 
-  test('new events added well when logging is restored', () {
-    final root = Logger.root;
-    final records = <LogRecord>[];
-    recordStackTraceAtLevel = Level.ALL;
-    root.onRecord.listen(records.add);
-    root.severe('hello');
-    root.warning('hello');
-    root.info('hello');
-    expect(records, hasLength(3));
-  });
+      test('could not add event when logging is canceled', () {
+        root.onRecord.listen(records.add);
+
+        root.cancelLogging();
+
+        root.severe('hello');
+        root.warning('hello');
+        root.info('hello');
+
+        expect(records, hasLength(0));
+      });
+
+      test('new events added well when logging is restored', () {
+        root.onRecord.listen(records.add);
+
+        root.cancelLogging();
+
+        root.onRecord.listen(records.add);
+
+        root.severe('hello');
+        root.warning('hello');
+        root.info('hello');
+
+        expect(records, hasLength(3));
+      });
+    },
+  );
 
   group('zone gets recorded to LogRecord', () {
     test('root zone', () {


### PR DESCRIPTION
To avoid cases like: 
1. Somebody use logging package for plugin/package development. 
2. I used this 3rd party solution and logging package for my development.
3. We do not use hierarchicalLoggingEnabled = true
4. Logger in 3rd party plugin/package can be configured just on the fly.
5. Somewhere  in  3rd party plugin/package used packageLogger.clearListeners()

As the result i have my app logger deconfigured because of clearListeners method logic(stream controller for my logger was cleared too). 

For examlpe package GoRouter uses setLogging method and i have to be carefull with the sequence of my app logger initialization and creation the instance of GoRouter.  GoRouter uses GoRouter.setLogger first time just while constructing with clearListeners for GoRouter(debugLogDiagnostics: true). Even more, i have to check every time that GoRouter.setLogging have nor been used again latter by other developers in my app.

Version changed to 2.0.0 due to breaking changes. Class Logger is implemented in some packages (as in build_runner_core with BuildForInputLogger).