### PR TITLE
add file copyrights and misc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://github.com/dart-lang/logging/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/logging/actions?query=workflow%3A"Dart+CI"+branch%3Amaster)
 [![Pub](https://img.shields.io/pub/v/logging.svg)](https://pub.dev/packages/logging)
+[![package publisher](https://img.shields.io/pub/publisher/logging.svg)](https://pub.dev/packages/logging/publisher)
 
 ## Initializing
 

--- a/lib/src/log_record.dart
+++ b/lib/src/log_record.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'level.dart';

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2019, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:collection';
 
@@ -55,7 +59,7 @@ class Logger {
   ///
   /// Calling `Logger(name)` will return the same instance whenever it is called
   /// with the same string name. Loggers created with this constructor are
-  /// retained indefinitely and available through [attachedLoggers];
+  /// retained indefinitely and available through [attachedLoggers].
   factory Logger(String name) =>
       _loggers.putIfAbsent(name, () => Logger._named(name));
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,5 +10,5 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dev_dependencies:
-  lints: ^1.0.0
+  lints: '>=1.0.0 <3.0.0'
   test: ^1.16.0


### PR DESCRIPTION
Some misc work to this package:

- add missing copyright headers to two files
- fix the dartdoc docs for a constructor
- widen the dep on `package:lints`
- add a markdown badge to the package readme

