### PR TITLE
Add a check that throws if a logger name ends with '.'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1-dev
+
+* Add a check that throws if a logger name ends with '.'.
+
 ## 1.1.0
 
 * Add `Logger.attachedLoggers` which exposes all loggers created with the

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -78,6 +78,10 @@ class Logger {
     if (name.startsWith('.')) {
       throw ArgumentError("name shouldn't start with a '.'");
     }
+    if (name.endsWith('.')) {
+      throw ArgumentError("name shouldn't end with a '.'");
+    }
+
     // Split hierarchical names (separated with '.').
     var dot = name.lastIndexOf('.');
     Logger? parent;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: logging
-version: 1.1.0
+version: 1.1.1-dev
 
 description: >-
   Provides APIs for debugging and error logging, similar to loggers in other

--- a/test/logging_test.dart
+++ b/test/logging_test.dart
@@ -75,6 +75,11 @@ void main() {
     expect(() => Logger('.c'), throwsArgumentError);
   });
 
+  test('logger name cannot end with a "."', () {
+    expect(() => Logger('a.'), throwsArgumentError);
+    expect(() => Logger('a..d'), throwsArgumentError);
+  });
+
   test('root level has proper defaults', () {
     expect(Logger.root, isNotNull);
     expect(Logger.root.parent, null);


### PR DESCRIPTION
Logger right now allows the creation of empty names if the full name is not empty, which resulted in bugs like #105. This fixes it by adding a check that is similar to `name shouldn't start with a '.'` in named logger creation. 

I have added a test to verify this fix. No loggers are created if this verification fails with ArgumentError.