### PR TITLE
Hierarchical logging documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,56 @@ Available logging methods are:
 + `log.finer(logged_content);`
 + `log.finest(logged_content);`
 
+## Configuration
+
+Loggers can be individually configured and listened to. When an individual logger has no
+specific configuration, it uses the configuration and any listeners found at `Logger.root`.
+
+To begin, set the global boolean `hierarchicalLoggingEnabled` to `true`.
+
+Then, create unique loggers and configure their `level` attributes and assign any listeners to
+their `onRecord` streams.
+
+
+```dart
+hierarchicalLoggingEnabled = true;
+
+Logger.root.level = Level.FINE;
+
+final log1 = Logger('WARNING+');
+log1.level = Level.WARNING;
+Logger.root.onRecord.listen((record) {
+  print('[WARNING+] ${record.message}');
+});
+
+final log2 = Logger('FINE+'); // Inherited from `Logger.root`
+log2.onRecord.listen((record) {
+  print('[FINE+]    ${record.message}');
+});
+
+log1.info('Will not print because too low level');
+log2.info(
+  'WILL print TWICE ([FINE+] and [WARNING+]) '
+  'because `log2` uses individual and root listeners',
+);
+
+log1.warning('WILL print ONCE because `log1` only uses root listener');
+log2.warning(
+  'WILL print TWICE because `log2` '
+  'uses individual and root listeners',
+);
+```
+
+Results in:
+
+```
+[FINE+]    WILL print TWICE ([FINE+] and [WARNING+]) because `log2` uses individual and root listeners
+[WARNING+] WILL print TWICE ([FINE+] and [WARNING+]) because `log2` uses individual and root listeners
+[WARNING+] WILL print ONCE because `log1` only uses root listener
+[FINE+]    WILL print TWICE because `log2` uses individual and root listeners
+[WARNING+] WILL print TWICE because `log2` uses individual and root listeners
+```
+
 ## Publishing automation
 
 For information about our publishing automation and release process, see


### PR DESCRIPTION
Adds an example for configuring specific loggers differently than `Logger.root`, e.g.,

```
final log = Logger('a');
log.level = Level.warning;
log.onRecord.listen((_) {});
```

Closes #132.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
