### PR TITLE
Send logs to Dart DevTools.

### DIFF
--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:collection';
+import 'dart:developer' as developer;
 
 import 'level.dart';
 import 'log_record.dart';
@@ -311,7 +312,19 @@ class Logger {
     }
   }
 
-  void _publish(LogRecord record) => _controller?.add(record);
+  void _publish(LogRecord record) {
+    developer.log(
+      record.message,
+      time: record.time,
+      sequenceNumber: record.sequenceNumber,
+      level: record.level.value,
+      name: record.loggerName,
+      zone: record.zone,
+      error: record.error,
+      stackTrace: record.stackTrace,
+    );
+    return _controller?.add(record);
+  }
 
   /// Top-level root [Logger].
   static final Logger root = Logger('');

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -323,7 +323,7 @@ class Logger {
       error: record.error,
       stackTrace: record.stackTrace,
     );
-    return _controller?.add(record);
+   _controller?.add(record);
   }
 
   /// Top-level root [Logger].


### PR DESCRIPTION
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExc3BoYmJrendhcWk5aW9wemJhbWVxZzh6cHV3bmM1YXVyeGo4bXBncSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/wxFRiFkKHlC6I/giphy-downsized.gif)

As part of some product excellence pursuits for [Dart Devtools](https://github.com/flutter/devtools) we would like to make sure that package:logging records are also sent to Dart Devtools.

TBD i'm going to reach out to package members to ask about the best way to test this.
