### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ First, set the root `Level`. All messages at or above the current level are sent
 Then, listen on the `onRecord` stream for `LogRecord` events. The `LogRecord`
 class has various properties for the message, error, logger name, and more.
 
-To listen for changed level notitfications use:
+To listen for changed level notifications use:
 
 ```dart
 Logger.root.onLevelChanged.listen((level) {


### PR DESCRIPTION
Simple fix for typo in README. 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
